### PR TITLE
Fix compatibility with chef < 12

### DIFF
--- a/cookbooks/cumulus/metadata.rb
+++ b/cookbooks/cumulus/metadata.rb
@@ -3,6 +3,6 @@ maintainer       'Cumulus Networks'
 maintainer_email 'ce-ceng@cumulusnetworks.com'
 license          'Apache v2.0'
 description      'Manage Cumulus Networks specific configuration'
-source_url       'https://github.com/CumulusNetworks/cumulus-linux-chef-modules'
+source_url       'https://github.com/CumulusNetworks/cumulus-linux-chef-modules' if respond_to?(:source_url)
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '1.0.0'


### PR DESCRIPTION
This fixes compatibility with chef 11 (and most likely chef 10, although I've not tested that).