### PR TITLE
Use yes/no instead of True/False, fix bridges.

### DIFF
--- a/cookbooks/cumulus/libraries/util.rb
+++ b/cookbooks/cumulus/libraries/util.rb
@@ -67,7 +67,7 @@ module Cumulus
       # The array of ports with any ranges prefixed with the 'glob' keyword
       #
       def prefix_glob_port_list(list = [])
-        out = []
+        out = ''
         list.each do |port|
           match = port.match(/^(.+)-(.+)$/)
           if match
@@ -75,8 +75,9 @@ module Cumulus
           else
             out << port
           end
+          out << ' '
         end
-        out
+        out.rstrip
       end
 
       ##

--- a/cookbooks/cumulus/providers/bond.rb
+++ b/cookbooks/cumulus/providers/bond.rb
@@ -41,7 +41,7 @@ action :create do
   ipv6 = new_resource.ipv6
   address = ipv4 + ipv6
 
-  config = { 'bond-slaves' => slaves.join(' '),
+  config = { 'bond-slaves' => slaves,
              'bond-miimon' => new_resource.miimon,
              'bond-min-links' => new_resource.min_links,
              'bond-mode' => new_resource.mode,

--- a/cookbooks/cumulus/providers/bridge.rb
+++ b/cookbooks/cumulus/providers/bridge.rb
@@ -36,7 +36,7 @@ action :create do
   address = ipv4 + ipv6
 
   config = { 'bridge-ports' => ports,
-             'bridge-stp' => new_resource.stp }
+             'bridge-stp' => Cumulus::Utils.bool_to_yn(new_resource.stp) }
 
   # Insert optional parameters
   config['address'] = address unless address.nil?
@@ -47,7 +47,7 @@ action :create do
   config['address-virtual'] = virtual_mac unless virtual_mac.nil?
 
   if new_resource.vlan_aware
-    config['bridge-vlan-aware'] = true
+    config['bridge-vlan-aware'] = 'yes'
 
     # vids & pvid are valid
     vids = new_resource.vids

--- a/cookbooks/cumulus/providers/interface.rb
+++ b/cookbooks/cumulus/providers/interface.rb
@@ -59,7 +59,7 @@ action :create do
     clagd_sys_mac = new_resource.clagd_sys_mac
     clagd_args = new_resource.clagd_args
 
-    config['clagd-enable'] = true
+    config['clagd-enable'] = 'yes'
     config['clagd-peer-ip'] = clagd_peer_ip unless clagd_peer_ip.nil?
     config['clagd-priority'] = clagd_priority unless clagd_priority.nil?
     config['clagd-sys-mac'] = clagd_sys_mac unless clagd_sys_mac.nil?

--- a/cookbooks/cumulus/providers/ports.rb
+++ b/cookbooks/cumulus/providers/ports.rb
@@ -25,7 +25,7 @@ action :create do
     action :create
   end
 
-  template '/etc/cumulus/ports.conf' do
+  port = template '/etc/cumulus/ports.conf' do
     cookbook 'cumulus'
     source 'ports.erb'
     variables(
@@ -39,5 +39,5 @@ action :create do
     mode '0600'
     backup false
   end
-  new_resource.updated_by_last_action(true)
+  new_resource.updated_by_last_action(port.updated_by_last_action?)
 end


### PR DESCRIPTION
Made yes/no consistent across all parameters.
Made prefix_glob_port_list return a string to fix bridges with more than one port definition.