### PR TITLE
Use Cumulus VX for test-kitchen testing

### DIFF
--- a/cookbooks/cumulus/.kitchen.yml
+++ b/cookbooks/cumulus/.kitchen.yml
@@ -3,13 +3,15 @@ driver:
   name: vagrant
 
 provisioner:
-  name: chef_zero
+  name: chef_solo
+  require_chef_omnibus: false
 
 platforms:
-  - name: ubuntu-14.04
+  - name: cumulus-vx-2.5.3
     driver:
-      box: opscode-ubuntu-14.04
-      box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-14.04_chef-provisionerless.box
+      box: cumulus-vx-2.5.3
+      provision: true
+      vagrantfiles: ['test/provision-chef.rb']
 
 suites:
   - name: default

--- a/cookbooks/cumulus/.rubocop.yml
+++ b/cookbooks/cumulus/.rubocop.yml
@@ -8,3 +8,5 @@ Metrics/PerceivedComplexity:
   Enabled: false
 Style/RedundantBegin:
   Enabled: false
+Style/RegexpLiteral:
+  Enabled: false

--- a/cookbooks/cumulus/test/cookbooks/cumulus-test/recipes/bridges.rb
+++ b/cookbooks/cumulus/test/cookbooks/cumulus-test/recipes/bridges.rb
@@ -14,7 +14,7 @@ end
 
 # Classic bridge driver over-ride all defaults
 cumulus_bridge 'br1' do
-  ports ['swp12-13']
+  ports ['swp13-14']
   ipv4 ['10.0.0.1/24', '192.168.1.0/16']
   ipv6 ['2001:db8:abcd::/48']
   alias_name 'classic bridge number 1'

--- a/cookbooks/cumulus/test/cookbooks/cumulus-test/recipes/default.rb
+++ b/cookbooks/cumulus/test/cookbooks/cumulus-test/recipes/default.rb
@@ -8,33 +8,10 @@
 #
 
 # Setup a skeleton fake Cumulus Linux environment
-%w( /etc/cumulus /usr/cumulus/bin /etc/network/ifupdown2/templates ).each do |cldir|
-  directory cldir do
-    recursive true
-  end
-end
-
 file '/usr/cumulus/bin/cl-license' do
   content '#!/bin/sh
     echo "Rocket Turtle!\nexpires=$(date +%s)\n$0 $@" > /etc/cumulus/.license.txt'
   mode '0755'
-end
-
-# Setup the Cumulus repository and install ifupdown2
-execute 'apt-update' do
-  command 'apt-get update'
-  action :nothing
-end
-
-file '/etc/apt/sources.list.d/cumulus.list' do
-  content 'deb [ arch=amd64 ] http://repo.cumulusnetworks.com CumulusLinux-2.5 main'
-  notifies :run, 'execute[apt-update]', :immediately
-end
-
-%w( python-ifupdown2 python-argcomplete python-ipaddr ).each do |pkg|
-  apt_package pkg do
-    options '--force-yes'
-  end
 end
 
 include_recipe "cumulus-test::ports"

--- a/cookbooks/cumulus/test/integration/default/serverspec/bridges_spec.rb
+++ b/cookbooks/cumulus/test/integration/default/serverspec/bridges_spec.rb
@@ -16,7 +16,7 @@ end
 describe file("#{intf_dir}/br1") do
   it { should be_file }
   its(:content) { should match(/iface br1/) }
-  its(:content) { should match(/bridge-ports glob swp12-13/) }
+  its(:content) { should match(/bridge-ports glob swp13-14/) }
   its(:content) { should match(/bridge-stp no/) }
   its(:content) { should match(/mtu 9000/) }
   its(:content) { should match(/mstpctl-treeprio 4096/) }

--- a/cookbooks/cumulus/test/provision-chef.rb
+++ b/cookbooks/cumulus/test/provision-chef.rb
@@ -1,0 +1,3 @@
+Vagrant.configure("2") do |config|
+  config.vm.provision :shell, inline: "apt-get update && apt-get install chef"
+end


### PR DESCRIPTION
Now that Cumulus VX is available use that instead of trying to make an Ubuntu box work like Cumulus Linux.