### PR TITLE
Fixing ifquery -o json comparison

### DIFF
--- a/cookbooks/cumulus/providers/bond.rb
+++ b/cookbooks/cumulus/providers/bond.rb
@@ -52,6 +52,8 @@ action :create do
 
   # Insert optional parameters
   config['address'] = address unless address.nil?
+  # If single address, don't use an array (for ifquery -o json equality test)
+  config['address'] = address[0] if address.class == Array && address.count == 1
   config['alias'] = "\"#{alias_name}\"" unless alias_name.nil?
   config['mtu'] = mtu unless mtu.nil?
   config['clag-id'] = clag_id unless clag_id.nil?
@@ -88,9 +90,10 @@ action :create do
 
   new = [{ 'auto' => true,
            'name' => name,
-           'config' => config,
-           'addr_method' => addr_method,
-           'addr_family' => addr_family }]
+           'config' => config }]
+
+  new[0]['addr_method'] = addr_method if addr_method
+  new[0]['addr_family'] = addr_family if addr_family
 
   current = Cumulus::Utils.if_to_hash(name)
 

--- a/cookbooks/cumulus/providers/bridge.rb
+++ b/cookbooks/cumulus/providers/bridge.rb
@@ -40,6 +40,8 @@ action :create do
 
   # Insert optional parameters
   config['address'] = address unless address.nil?
+  # If single address, don't use an array (for ifquery -o json equality test)
+  config['address'] = address[0] if address.class == Array && address.count == 1
   config['mtu'] = mtu unless mtu.nil?
   config['mstpctl-treeprio'] = mstpctl_treeprio unless mstpctl_treeprio.nil?
   config['alias'] = "\"#{alias_name}\"" unless alias_name.nil?
@@ -62,9 +64,10 @@ action :create do
 
   new = [{ 'auto' => true,
            'name' => name,
-           'config' => config,
-           'addr_method' => addr_method,
-           'addr_family' => addr_family }]
+           'config' => config }]
+
+  new[0]['addr_method'] = addr_method if addr_method
+  new[0]['addr_family'] = addr_family if addr_family
 
   current = Cumulus::Utils.if_to_hash(name)
 

--- a/cookbooks/cumulus/providers/interface.rb
+++ b/cookbooks/cumulus/providers/interface.rb
@@ -44,6 +44,8 @@ action :create do
 
   # Insert optional parameters
   config['address'] = address unless address.nil?
+  # If single address, don't use an array (for ifquery -o json equality test)
+  config['address'] = address[0] if address.class == Array && address.count == 1
   config['alias'] = "\"#{alias_name}\"" unless alias_name.nil?
   config['mtu'] = mtu unless mtu.nil?
   config['bridge-vids'] = vids unless vids.nil?
@@ -79,9 +81,10 @@ action :create do
 
   new = [{ 'auto' => true,
            'name' => name,
-           'config' => config,
-           'addr_method' => addr_method,
-           'addr_family' => addr_family }]
+           'config' => config }]
+
+  new[0]['addr_method'] = addr_method if addr_method
+  new[0]['addr_family'] = addr_family if addr_family
 
   current = Cumulus::Utils.if_to_hash(name)
 


### PR DESCRIPTION
This pull request makes it so that the Hash equality test between the desired interface config and the ifquery -o json output returns true if no changes need to be made.  Now updated_by_last_action (and therefore 'notifies', in recipes) behave correctly.