### PR TITLE
Fixing virtual_mac and virtual_ip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ cookbooks/cumulus/.bundle/
 cookbooks/cumulus/Berksfile.lock
 cookbooks/cumulus/Gemfile.lock
 cookbooks/cumulus/vendor/
+*.swp

--- a/cookbooks/cumulus/providers/bond.rb
+++ b/cookbooks/cumulus/providers/bond.rb
@@ -61,8 +61,7 @@ action :create do
   config['clag-id'] = clag_id unless clag_id.nil?
   config['bridge-vids'] = vids unless vids.nil?
   config['bridge-pvid'] = pvid unless pvid.nil?
-  config['address-virtual'] = virtual_mac unless virtual_mac.nil?
-  config['address-virtual'] = virtual_ip unless virtual_ip.nil?
+  config['address-virtual'] = [virtual_mac, virtual_ip].compact.join(' ') unless virtual_ip.nil?
   config['post-up'] = post_up unless post_up.nil?
   config['pre-down'] = pre_down unless post_up.nil?
   config['mstpctl-portnetwork'] = Cumulus::Utils.bool_to_yn(mstpctl_portnetwork) unless mstpctl_portnetwork.nil?

--- a/cookbooks/cumulus/providers/bond.rb
+++ b/cookbooks/cumulus/providers/bond.rb
@@ -61,7 +61,7 @@ action :create do
   config['clag-id'] = clag_id unless clag_id.nil?
   config['bridge-vids'] = vids unless vids.nil?
   config['bridge-pvid'] = pvid unless pvid.nil?
-  config['address-virtual'] = [virtual_mac, virtual_ip].compact.join(' ') unless virtual_ip.nil?
+  config['address-virtual'] = [virtual_mac, virtual_ip].compact.join(' ') unless virtual_ip.nil? && virtual_mac.nil?
   config['post-up'] = post_up unless post_up.nil?
   config['pre-down'] = pre_down unless post_up.nil?
   config['mstpctl-portnetwork'] = Cumulus::Utils.bool_to_yn(mstpctl_portnetwork) unless mstpctl_portnetwork.nil?

--- a/cookbooks/cumulus/providers/bridge.rb
+++ b/cookbooks/cumulus/providers/bridge.rb
@@ -47,8 +47,7 @@ action :create do
   config['mtu'] = mtu unless mtu.nil?
   config['mstpctl-treeprio'] = mstpctl_treeprio unless mstpctl_treeprio.nil?
   config['alias'] = "\"#{alias_name}\"" unless alias_name.nil?
-  config['address-virtual'] = virtual_ip unless virtual_ip.nil?
-  config['address-virtual'] = virtual_mac unless virtual_mac.nil?
+  config['address-virtual'] = [virtual_mac, virtual_ip].compact.join(' ') unless virtual_ip.nil?
   config['post-up'] = post_up unless post_up.nil?
   config['pre-down'] = pre_down unless post_up.nil?
 

--- a/cookbooks/cumulus/providers/bridge.rb
+++ b/cookbooks/cumulus/providers/bridge.rb
@@ -47,7 +47,7 @@ action :create do
   config['mtu'] = mtu unless mtu.nil?
   config['mstpctl-treeprio'] = mstpctl_treeprio unless mstpctl_treeprio.nil?
   config['alias'] = "\"#{alias_name}\"" unless alias_name.nil?
-  config['address-virtual'] = [virtual_mac, virtual_ip].compact.join(' ') unless virtual_ip.nil?
+  config['address-virtual'] = [virtual_mac, virtual_ip].compact.join(' ') unless virtual_ip.nil? && virtual_mac.nil?
   config['post-up'] = post_up unless post_up.nil?
   config['pre-down'] = pre_down unless post_up.nil?
 

--- a/cookbooks/cumulus/providers/interface.rb
+++ b/cookbooks/cumulus/providers/interface.rb
@@ -52,7 +52,7 @@ action :create do
   config['mtu'] = mtu unless mtu.nil?
   config['bridge-vids'] = vids unless vids.nil?
   config['bridge-pvid'] = pvid unless pvid.nil?
-  config['address-virtual'] = [virtual_mac, virtual_ip].compact.join(' ') unless virtual_ip.nil?
+  config['address-virtual'] = [virtual_mac, virtual_ip].compact.join(' ') unless virtual_ip.nil? && virtual_mac.nil?
   config['post-up'] = post_up unless post_up.nil?
   config['pre-down'] = pre_down unless post_up.nil?
   config['mstpctl-portnetwork'] = Cumulus::Utils.bool_to_yn(mstpctl_portnetwork) unless mstpctl_portnetwork.nil?

--- a/cookbooks/cumulus/providers/interface.rb
+++ b/cookbooks/cumulus/providers/interface.rb
@@ -52,8 +52,7 @@ action :create do
   config['mtu'] = mtu unless mtu.nil?
   config['bridge-vids'] = vids unless vids.nil?
   config['bridge-pvid'] = pvid unless pvid.nil?
-  config['address-virtual'] = virtual_mac unless virtual_mac.nil?
-  config['address-virtual'] = virtual_ip unless virtual_ip.nil?
+  config['address-virtual'] = [virtual_mac, virtual_ip].compact.join(' ') unless virtual_ip.nil?
   config['post-up'] = post_up unless post_up.nil?
   config['pre-down'] = pre_down unless post_up.nil?
   config['mstpctl-portnetwork'] = Cumulus::Utils.bool_to_yn(mstpctl_portnetwork) unless mstpctl_portnetwork.nil?

--- a/cookbooks/cumulus/test/cookbooks/cumulus-test/recipes/bridges.rb
+++ b/cookbooks/cumulus/test/cookbooks/cumulus-test/recipes/bridges.rb
@@ -22,6 +22,7 @@ cumulus_bridge 'br1' do
   stp false
   mstpctl_treeprio 4096
   virtual_ip '192.168.100.1'
+  virtual_mac 'aa:bb:cc:dd:ee:ff'
 end
 
 # New bridge driver with defaults
@@ -42,7 +43,6 @@ cumulus_bridge 'bridge3' do
   mtu 9000
   stp false
   mstpctl_treeprio 4096
-  virtual_mac 'aa:bb:cc:dd:ee:ff'
   post_up [
     "ip route add 10.0.0.0/8 via 192.168.200.2",
     "ip route add 172.16.0.0/12 via 192.168.200.2"

--- a/cookbooks/cumulus/test/cookbooks/cumulus-test/recipes/interfaces.rb
+++ b/cookbooks/cumulus/test/cookbooks/cumulus-test/recipes/interfaces.rb
@@ -42,7 +42,9 @@ cumulus_interface 'swp2' do
 end
 
 # Test post_up and pre_down as String instead of Array
+# Test using virtual_ip for both mac and IP
 cumulus_interface 'swp3' do
   post_up "ip route add 192.168.0.0/16 via 192.168.200.2"
   pre_down "ip route del 192.168.0.0/16 via 192.168.200.2"
+  virtual_ip '11:22:33:44:55:66 192.168.10.1'
 end

--- a/cookbooks/cumulus/test/integration/default/serverspec/bonds_spec.rb
+++ b/cookbooks/cumulus/test/integration/default/serverspec/bonds_spec.rb
@@ -30,7 +30,7 @@ describe file("#{intf_dir}/bond1") do
   its(:content) { should match(/bond-xmit-hash-policy layer2/) }
   its(:content) { should match(/address 192.168.1.0\/16/) }
   its(:content) { should match(/address 2001:db8:abcd::\/48/) }
-  its(:content) { should match(/address-virtual 192.168.20.1/) }
+  its(:content) { should match(/address-virtual 11:22:33:44:55:FF 192.168.20.1/) }
   its(:content) { should match(/mstpctl-portnetwork yes/) }
   its(:content) { should match(/mstpctl-portadminedge yes/) }
   its(:content) { should match(/mstpctl-bpduguard yes/) }

--- a/cookbooks/cumulus/test/integration/default/serverspec/bridges_spec.rb
+++ b/cookbooks/cumulus/test/integration/default/serverspec/bridges_spec.rb
@@ -22,6 +22,7 @@ describe file("#{intf_dir}/br1") do
   its(:content) { should match(/mstpctl-treeprio 4096/) }
   its(:content) { should match(/address 10.0.0.1\/24/) }
   its(:content) { should match(/address 2001:db8:abcd::\/48/) }
+  its(:content) { should match(/address-virtual aa:bb:cc:dd:ee:ff 192.168.100.1/) }
 end
 
 # New bridge driver

--- a/cookbooks/cumulus/test/integration/default/serverspec/interfaces_spec.rb
+++ b/cookbooks/cumulus/test/integration/default/serverspec/interfaces_spec.rb
@@ -51,7 +51,7 @@ describe file("#{intf_dir}/swp2") do
   its(:content) { should match(/mstpctl-portnetwork yes/) }
   its(:content) { should match(/mstpctl-portadminedge yes/) }
   its(:content) { should match(/mstpctl-bpduguard yes/) }
-  its(:content) { should match(/address-virtual/) }
+  its(:content) { should match(/address-virtual 11:22:33:44:55:66 192.168.10.1/) }
   its(:content) { should match(/post-up ip route add 10.0.0.0\/8 via 192.168.200.2/) }
   its(:content) { should match(/post-up ip route add 172.16.0.0\/12 via 192.168.200.2/) }
   its(:content) { should match(/pre-down ip route del 10.0.0.0\/8 via 192.168.200.2/) }
@@ -63,4 +63,5 @@ describe file("#{intf_dir}/swp3") do
   its(:content) { should match(/iface swp3/) }
   its(:content) { should match(/post-up ip route add 192.168.0.0\/16 via 192.168.200.2/) }
   its(:content) { should match(/pre-down ip route del 192.168.0.0\/16 via 192.168.200.2/) }
+  its(:content) { should match(/address-virtual 11:22:33:44:55:66 192.168.10.1/) }
 end


### PR DESCRIPTION
Heyo!

As it stands, virtual_ip and virutal_mac are semi-broken.  You can only use one of them, as you can see [here](https://github.com/CumulusNetworks/cumulus-linux-chef-modules/blob/31037a0386d246f0db3d674320320a5ba42f2b8d/cookbooks/cumulus/providers/interface.rb#L55-L56), where `config['address-virtual']` is assigned twice with two different values.

This PR supports the existing behavior (just using virtual_ip or virtual_mac for both MAC and IP), as well as adding the ability to assign them individually, which appears to be the intended method.

Let me know if you see any problems!