### PR TITLE
Place bridge-vids on one line

### DIFF
--- a/cookbooks/cumulus/providers/interface.rb
+++ b/cookbooks/cumulus/providers/interface.rb
@@ -50,7 +50,7 @@ action :create do
   config['address'] = address[0] if address.class == Array && address.count == 1
   config['alias'] = alias_name unless alias_name.nil?
   config['mtu'] = mtu unless mtu.nil?
-  config['bridge-vids'] = vids unless vids.nil?
+  config['bridge-vids'] = vids.join(" ") unless vids.nil?
   config['bridge-pvid'] = pvid unless pvid.nil?
   config['address-virtual'] = [virtual_mac, virtual_ip].compact.join(' ') unless virtual_ip.nil? && virtual_mac.nil?
   config['post-up'] = post_up unless post_up.nil?

--- a/cookbooks/cumulus/test/cookbooks/cumulus-test/recipes/interfaces.rb
+++ b/cookbooks/cumulus/test/cookbooks/cumulus-test/recipes/interfaces.rb
@@ -23,7 +23,7 @@ cumulus_interface 'swp2' do
   # clagd_priority 1
   # clagd_peer_ip '10.1.2.3'
   # clagd_sys_mac 'aa:bb:cc:dd:ee:ff'
-  vids ['1-4094']
+  vids ['1', '2', '4-4094']
   pvid 1
   alias_name 'interface swp2'
   virtual_mac '11:22:33:44:55:66'

--- a/cookbooks/cumulus/test/integration/default/serverspec/interfaces_spec.rb
+++ b/cookbooks/cumulus/test/integration/default/serverspec/interfaces_spec.rb
@@ -43,7 +43,7 @@ describe file("#{intf_dir}/swp2") do
   its(:content) { should match(/address 192.168.200.1/) }
   its(:content) { should match(/address 2001:db8:5678::/) }
   its(:content) { should match(/mtu 9000/) }
-  its(:content) { should match(/bridge-vids 1-4094/) }
+  its(:content) { should match(/bridge-vids 1 2 4-4094/) }
   its(:content) { should match(/bridge-pvid 1/) }
   its(:content) { should match(/link-speed 1000/) }
   its(:content) { should match(/link-duplex full/) }


### PR DESCRIPTION
Specifying multiple vids in an array to bridge-vids of the cumulus_interfaces lwrp 

```ruby
cumulus_interface 'swp33' do
...
  bridge-vids [ 88, 100 ]
end
```

produces the following output: 

```
auto swp33
iface swp33
  bridge-vids 88
  bridge-vids 100
```

This results in only the tag 88 being applied to the port which is not expected.

```
root@leaf1:~# bridge vlan show swp33
port    vlan ids
swp33    1 PVID Egress Untagged
         88
```

This is because of the underlying ifquery's output: 

```bash
root@cumulus:~# cat swp1.json
{
	"name": "swp1",
	"auto": true,
	"config" : {
		"bridge-vids": [ 10, 11, 12 ]
	}
}
root@cumulus:~# cat swp1.json | ifquery -i - -t json swp1
auto swp1
iface swp1
	bridge-vids 10
	bridge-vids 11
	bridge-vids 12
```

Passing an string instead keeps all the values for bridge-vids in one line: 

```bash
root@cumulus:~# cat swp1.json
{
	"name": "swp1",
	"auto": true,
	"config" : {
		"bridge-vids": "10 11 12"
	}
}
root@cumulus:~# cat swp1.json | ifquery -i - -t json swp1
auto swp1
iface swp1
	bridge-vids 10 11 12
```
I have joined the array in the interfaces provider so that value passed to ifquery is a string and not an array: 

