### PR TITLE
fix unless clause for pre_down

### DIFF
--- a/cookbooks/cumulus/providers/interface.rb
+++ b/cookbooks/cumulus/providers/interface.rb
@@ -54,7 +54,7 @@ action :create do
   config['bridge-pvid'] = pvid unless pvid.nil?
   config['address-virtual'] = [virtual_mac, virtual_ip].compact.join(' ') unless virtual_ip.nil? && virtual_mac.nil?
   config['post-up'] = post_up unless post_up.nil?
-  config['pre-down'] = pre_down unless post_up.nil?
+  config['pre-down'] = pre_down unless pre_down.nil?
   config['mstpctl-portnetwork'] = Cumulus::Utils.bool_to_yn(mstpctl_portnetwork) unless mstpctl_portnetwork.nil?
   config['mstpctl-portadminedge'] = Cumulus::Utils.bool_to_yn(mstpctl_portadminedge) unless mstpctl_portadminedge.nil?
   config['mstpctl-bpduguard'] = Cumulus::Utils.bool_to_yn(mstpctl_bpduguard) unless mstpctl_bpduguard.nil?


### PR DESCRIPTION
This bug causes a pre-down to be included in the config whenever a post-down is present. This is a problem when no pre-down actions are specified. 