### PR TITLE
convert mtu value to string - to match ifqeury

### DIFF
--- a/cookbooks/cumulus/libraries/util.rb
+++ b/cookbooks/cumulus/libraries/util.rb
@@ -230,6 +230,31 @@ module Cumulus
       def bool_to_yn(bool)
         bool ? 'yes' : 'no'
       end
+
+      ##
+      # Convert an integer to string (works for integers and arrays)
+      #
+      # = Example
+      #
+      #   convert_int_to_string(401)
+      #   => '401'
+      #
+      #   convert_int_to_string([401,402])
+      #   => ['401','402']
+      #
+      # = Parameters::
+      # object::
+      #   Integer or Array value to convert from
+      #
+      def convert_int_to_string(object)
+        if object.is_a?(Integer)
+          object.to_s
+        elsif object.is_a?(Array)
+          object.map! {|obj| convert_int_to_string(obj)}
+        else
+          object
+        end
+      end
     end
   end
 end

--- a/cookbooks/cumulus/providers/interface.rb
+++ b/cookbooks/cumulus/providers/interface.rb
@@ -89,6 +89,9 @@ action :create do
   # Family is always 'inet' if a method is set
   addr_family = addr_method.nil? ? nil : 'inet'
 
+  # change integers to strings (ifquery returns strings in if_to_hash)
+  config.each {|k,v| config[k] = Cumulus::Utils.convert_int_to_string(v)}
+
   new = [{ 'auto' => auto,
            'name' => name,
            'config' => config }]


### PR DESCRIPTION
when setting mtu for an interface using the lwrp the resource gets updated on every chef run because the ifquery returns the mtu value as a string.

fix to set the mtu as a string (instead of an integer) in the config hash map.
