### PR TITLE
fix bond data when no address is set

### DIFF
--- a/cookbooks/cumulus/providers/bond.rb
+++ b/cookbooks/cumulus/providers/bond.rb
@@ -44,7 +44,7 @@ action :create do
 
   ipv4 = new_resource.ipv4
   ipv6 = new_resource.ipv6
-  address = ipv4 + ipv6
+  address = (ipv4 + ipv6).empty? ? nil : ipv4 + ipv6
 
   config = { 'bond-slaves' => slaves.join(' '),
              'bond-miimon' => new_resource.miimon,


### PR DESCRIPTION
same fix that was done for interface.rb

When no address is set in the cumulus_bond resource it will be updated on every chef run because it passes an empty array of address to ifquery
