### PR TITLE
fix link-speed-integer>speed-string

### DIFF
--- a/cookbooks/cumulus/README.md
+++ b/cookbooks/cumulus/README.md
@@ -192,7 +192,7 @@ Configure `swp33` as a 1GbE port with a single IPv4 address:
 ````ruby
 cumulus_interface 'swp33' do
   ipv4 ['10.30.1.1/24']
-  link_speed 1000
+  speed '1000'
 end
 ````
 

--- a/cookbooks/cumulus/metadata.rb
+++ b/cookbooks/cumulus/metadata.rb
@@ -5,4 +5,4 @@ license          'Apache v2.0'
 description      'Manage Cumulus Networks specific configuration'
 source_url       'https://github.com/CumulusNetworks/cumulus-linux-chef-modules' if respond_to?(:source_url)
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.2.1'
+version          '1.2.2'


### PR DESCRIPTION
Fixing the example to use the right param name and a string