### PR TITLE
Fix bond provider

### DIFF
--- a/cookbooks/cumulus/README.md
+++ b/cookbooks/cumulus/README.md
@@ -192,7 +192,7 @@ Configure `swp33` as a 1GbE port with a single IPv4 address:
 ````ruby
 cumulus_interface 'swp33' do
   ipv4 ['10.30.1.1/24']
-  link_speed 1000
+  speed '1000'
 end
 ````
 

--- a/cookbooks/cumulus/metadata.rb
+++ b/cookbooks/cumulus/metadata.rb
@@ -5,4 +5,4 @@ license          'Apache v2.0'
 description      'Manage Cumulus Networks specific configuration'
 source_url       'https://github.com/CumulusNetworks/cumulus-linux-chef-modules' if respond_to?(:source_url)
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.2.1'
+version          '1.2.2'

--- a/cookbooks/cumulus/metadata.rb
+++ b/cookbooks/cumulus/metadata.rb
@@ -5,4 +5,4 @@ license          'Apache v2.0'
 description      'Manage Cumulus Networks specific configuration'
 source_url       'https://github.com/CumulusNetworks/cumulus-linux-chef-modules' if respond_to?(:source_url)
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.2.2'
+version          '1.2.3'

--- a/cookbooks/cumulus/providers/bond.rb
+++ b/cookbooks/cumulus/providers/bond.rb
@@ -93,6 +93,8 @@ action :create do
     config['bond-lacp-bypass-period'] = lacp_bypass_period unless lacp_bypass_period.nil?
   end
 
+  config.merge!(config) { |_k, v| v.to_s }
+
   new = [{ 'auto' => true,
            'name' => name,
            'config' => config }]


### PR DESCRIPTION
There is an issue with the recent ifupdown2 (via ifquery in this specific case) that requires all the numerical inputs to be strings